### PR TITLE
Basic history page

### DIFF
--- a/src/History.tsx
+++ b/src/History.tsx
@@ -1,7 +1,12 @@
 import React from "react";
+import ImageSlideshow from "./ImageSlideshow";
 
 function History(): React.ReactElement {
-    return <div>Hello world</div>;
+    return <>
+    <h1>History of buses</h1>
+    The <a href="https://madeby.tfl.gov.uk/2024/10/18/corporate-archives-top-stories/">modern incarnation of TfL</a> was created in July of the year 2000, but it has been built upon the infrastructure developed as early back as 1863!
+    <ImageSlideshow />
+    </>
 }
 
 export default History;

--- a/src/ImageSlideshow.tsx
+++ b/src/ImageSlideshow.tsx
@@ -1,0 +1,43 @@
+import { useState } from "react";
+
+const ImageSlideshow = () => {
+    const [counter, setCounter] = useState(0);
+
+    const images = [
+        {
+            title: 'Oyster card introduced',
+            year: 2003,
+            imageurl: 'https://wise.com/imaginary/oyster-card-in-uk_124338035.jpg',
+            caption: 'The introduction of the Oyster smart card streamlined travel in London.'
+        },
+        {
+            title: 'Wheelchair-accessible buses',
+            year: 2005,
+            imageurl: 'https://wheelsforwellbeing.org.uk/wp-content/uploads/2022/01/7677594164_5d1636b048_c.jpg',
+            caption: 'All London buses were made wheelchair-accessible.'
+        }
+        
+    ];
+
+    const incrementCounter = () => {
+        setCounter(prevCounter => Math.min(prevCounter + 1, images.length - 1));
+    }
+
+    const decrementCounter = () => {
+        setCounter(prevCounter => Math.max(prevCounter - 1, 0));
+    }
+
+
+    return <>
+        <h2>{images[counter].title}</h2>
+        <p>{images[counter].year}</p>
+        <img src={images[counter].imageurl} width="600px"></img>
+        <p>{images[counter].caption}</p>
+        <span>
+            <button onClick={decrementCounter} disabled={counter == 0}>Previous</button>
+            <button onClick={incrementCounter} disabled={counter == images.length - 1}>Next</button>
+        </span>
+    </>
+}
+
+export default ImageSlideshow;


### PR DESCRIPTION
A basic page about the history of buses! With a slideshow that the user can click through, showing off images, links, buttons, etc.

At some point it would probably be worth adding a navigation bar to the main page through which to access this - at the moment, you have to go to the `/history` endpoint - but that's probably best suited to a separate commit.

<img width="1542" height="1061" alt="Screenshot 2025-07-10 141137" src="https://github.com/user-attachments/assets/e9a8395a-a728-49b4-a3ab-9aae73b42feb" />
<img width="1587" height="1137" alt="Screenshot 2025-07-10 141152" src="https://github.com/user-attachments/assets/2f9a386e-f350-4501-b507-313b34835790" />
