### PR TITLE
Nicer styling of History page using Bootstrap

### DIFF
--- a/src/History.tsx
+++ b/src/History.tsx
@@ -2,11 +2,12 @@ import React from "react";
 import ImageSlideshow from "./ImageSlideshow";
 
 function History(): React.ReactElement {
-    return <>
+    return <div style={{margin: '10px', textAlign: 'center'}}>
     <h1>History of buses</h1>
     The <a href="https://madeby.tfl.gov.uk/2024/10/18/corporate-archives-top-stories/">modern incarnation of TfL</a> was created in July of the year 2000, but it has been built upon the infrastructure developed as early back as 1863!
+    <hr></hr>
     <ImageSlideshow />
-    </>
+    </div>
 }
 
 export default History;

--- a/src/ImageSlideshow.tsx
+++ b/src/ImageSlideshow.tsx
@@ -28,16 +28,16 @@ const ImageSlideshow = () => {
     }
 
 
-    return <>
+    return <div style={{textAlign: 'center', margin: '10px'}}>
         <h2>{images[counter].title}</h2>
         <p>{images[counter].year}</p>
         <img src={images[counter].imageurl} width="600px"></img>
         <p>{images[counter].caption}</p>
-        <span>
-            <button onClick={decrementCounter} disabled={counter == 0}>Previous</button>
+        <div style={{textAlign: 'center'}}>
+            <button style={{marginRight: '50px'}} onClick={decrementCounter} disabled={counter == 0}>Previous</button>
             <button onClick={incrementCounter} disabled={counter == images.length - 1}>Next</button>
-        </span>
-    </>
+        </div>
+    </div>
 }
 
 export default ImageSlideshow;

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -5,6 +5,8 @@ import App from './App';
 import History from './History';
 import reportWebVitals from './reportWebVitals';
 import {BrowserRouter, Route, Routes} from "react-router-dom";
+import 'bootstrap/dist/css/bootstrap.css';
+
 
 const root = ReactDOM.createRoot(
   document.getElementById('root') as HTMLElement


### PR DESCRIPTION
Just some improvements to the styling of the History page, so that it looks a little cleaner.

Before:
<img width="1587" height="1137" alt="Screenshot 2025-07-10 141152" src="https://github.com/user-attachments/assets/f2b7542a-4594-4b4d-889f-d86697f9a006" />



After:
<img width="3434" height="1915" alt="Screenshot 2025-07-10 151206" src="https://github.com/user-attachments/assets/110ecf68-500a-44fa-a212-bf499a7b5643" />


