### PR TITLE
Custom number of stops

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -26,6 +26,8 @@ const StopComponent = async (stopData: StopData, postcode: string): Promise<Reac
 
 function App(): React.ReactElement {
   const [postcode, setPostcode] = useState<string>("");
+  const [numberOfStops, setNumberOfStops] = useState<number>(2);
+
   const [tableData, setTableData] = useState<string>("");
   const [error, setError] = useState("");
   const [loading, setLoading] = useState(false);
@@ -58,7 +60,7 @@ function App(): React.ReactElement {
     // console.log(postcode);
     setLoading(true);
     // very basic testing string, you'll likely return a list of strings or JSON objects instead!
-    const [stopData, error] = await fetchData(postcode);
+    const [stopData, error] = await fetchData(postcode, numberOfStops);
     setError(error);
     const stopComponents: Map<number, React.ReactElement> = stops;
     for (var _stop of stopData) {
@@ -70,16 +72,22 @@ function App(): React.ReactElement {
   }
 
   function updatePostcode(data: React.ChangeEvent<HTMLInputElement>): void {
-    setPostcode(data.target.value)
+    setPostcode(data.target.value);
+  }
+
+  function updateNumberOfStops(data: React.ChangeEvent<HTMLInputElement>): void {
+    setNumberOfStops(+data.target.value);
   }
 
   return <>
     <center>
       <h1>&#128652; BusBoard</h1>
       <form action="" onSubmit={formHandler}>
-        <label style={{display: "block"}} htmlFor="postcodeInput"> Postcode </label>
+        <label style={{display: "block"}} htmlFor="postcodeInput"> Postcode:</label>
         <input style={{display: "block"}} type="text" id="postcodeInput" onChange={updatePostcode}/>
-        <input type="submit" value="Add"/>{loading &&
+        <label style={{display: "block"}} htmlFor="postcodeInput"> Max number of stops:</label>
+        <input style={{display: "block"}} type="text" id="postcodeInput" value={numberOfStops} onChange={updateNumberOfStops}/>
+        <input style={{margin: '5px'}} type="submit" value="Add"/>{loading &&
         <div className="spinner-border spinner-border-sm"></div>
         }
       </form>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -26,7 +26,7 @@ const StopComponent = async (stopData: StopData, postcode: string): Promise<Reac
 
 function App(): React.ReactElement {
   const [postcode, setPostcode] = useState<string>("");
-  const [numberOfStops, setNumberOfStops] = useState<number>(2);
+  const [numberOfStops, setNumberOfStops] = useState<string>("2");
 
   const [tableData, setTableData] = useState<string>("");
   const [error, setError] = useState("");
@@ -60,7 +60,7 @@ function App(): React.ReactElement {
     // console.log(postcode);
     setLoading(true);
     // very basic testing string, you'll likely return a list of strings or JSON objects instead!
-    const [stopData, error] = await fetchData(postcode, numberOfStops);
+    const [stopData, error] = await fetchData(postcode, +numberOfStops);
     setError(error);
     const stopComponents: Map<number, React.ReactElement> = stops;
     for (var _stop of stopData) {
@@ -76,7 +76,7 @@ function App(): React.ReactElement {
   }
 
   function updateNumberOfStops(data: React.ChangeEvent<HTMLInputElement>): void {
-    setNumberOfStops(+data.target.value);
+    setNumberOfStops(data.target.value);
   }
 
   return <>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -75,7 +75,7 @@ function App(): React.ReactElement {
 
   return <>
     <center>
-      <h1> BusBoard</h1>
+      <h1>&#128652; BusBoard</h1>
       <form action="" onSubmit={formHandler}>
         <label style={{display: "block"}} htmlFor="postcodeInput"> Postcode </label>
         <input style={{display: "block"}} type="text" id="postcodeInput" onChange={updatePostcode}/>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,13 +2,13 @@ import React, {useEffect, useRef, useState} from 'react';
 import {ArrivalData, fetchData, StopData} from "./utils";
 import 'bootstrap/dist/css/bootstrap.css';
 
-const StopComponent = async (stopData: StopData): Promise<React.ReactElement> => {
+const StopComponent = async (stopData: StopData, postcode: string): Promise<React.ReactElement> => {
 
   const arrivals = await stopData.getNextArrivals();
 
   return <>
     <div>
-      <p>{stopData.getName()} - {Math.round(stopData.getDistance())} metres from [POSTCODE]</p>
+      <p>{stopData.getName()} - {Math.round(stopData.getDistance())} metres from {postcode}</p>
       <table>
         <tr>
           <th>Line ID</th>
@@ -62,7 +62,7 @@ function App(): React.ReactElement {
     setError(error);
     const stopComponents: Map<number, React.ReactElement> = stops;
     for (var _stop of stopData) {
-      stopComponents.set(_stop.getStopId(), await StopComponent(_stop));
+      stopComponents.set(_stop.getStopId(), await StopComponent(_stop, postcode));
     }
     setStops(stopComponents);
     setLoading(false);

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -67,10 +67,10 @@ const getPostcodeData = async (postcode: string) => {
     return await postcodeResponse.json();
 }
 
-const getNearestStops = async (lat: number, long: number) => {
+const getNearestStops = async (lat: number, long: number, numberOfStops: number) => {
     const stopsResponse = await fetch(`https://api.tfl.gov.uk/StopPoint/?lat=${lat}&lon=${long}&stopTypes=NaptanPublicBusCoachTram&app_key=${APP_KEY}`);
     const stopsJson = await stopsResponse.json();
-    return stopsJson.stopPoints.slice(0, NUMBER_OF_STOPS);
+    return stopsJson.stopPoints.slice(0, numberOfStops);
 }
 
 const getUpcomingBuses = async (stopId: number) => {
@@ -80,14 +80,14 @@ const getUpcomingBuses = async (stopId: number) => {
     return nextBusesJson;
 }
 
-export const fetchData = async (postcode: string): Promise<[StopData[], string]> => {
+export const fetchData = async (postcode: string, numberOfStops: number): Promise<[StopData[], string]> => {
     //const postcode: string = readlineSync.question('Enter postcode: ');
     let postcodeJson;
     postcodeJson = await getPostcodeData(postcode);
     if ('error' in postcodeJson) {
         return [[], postcodeJson.error];
     }
-    const stops = await getNearestStops(postcodeJson.result.latitude, postcodeJson.result.longitude);
+    const stops = await getNearestStops(postcodeJson.result.latitude, postcodeJson.result.longitude, numberOfStops);
 
     var stopJSON: StopData[] = [];
 


### PR DESCRIPTION
This allows the user to choose the maximum number of nearest stops to the entered postcode that they want to add (this is a 'maximum', rather than the actual number, since the API will only return a certain number of bus stops).

Can add just a single (nearest) stop, rather than 2:
<img width="1956" height="1598" alt="Screenshot 2025-07-10 162643" src="https://github.com/user-attachments/assets/f070529b-71f6-41ab-b8f4-002fd26e7a42" />


