### PR TITLE
More slides for the History page

### DIFF
--- a/src/ImageSlideshow.tsx
+++ b/src/ImageSlideshow.tsx
@@ -15,6 +15,18 @@ const ImageSlideshow = () => {
             year: 2005,
             imageurl: 'https://wheelsforwellbeing.org.uk/wp-content/uploads/2022/01/7677594164_5d1636b048_c.jpg',
             caption: 'All London buses were made wheelchair-accessible.'
+        },
+        {
+            title: 'iBus',
+            year: 2009,
+            imageurl: 'https://alchetron.com/cdn/ibus-london-e3a5cd17-b7ec-4eeb-957d-17d1069ae3c-resize-750.jpg',
+            caption: 'Roll out of iBus, providing Nextstop audio and signs and live information on apps and the web'
+        },
+        {
+            title: 'TfL Go',
+            year: 2021,
+            imageurl: 'https://tfl.gov.uk/cdn/static/cms/images/promos/tfl-go-jp_rdax_400x300.jpg',
+            caption: 'The first journey planning app released by TfL'
         }
         
     ];

--- a/src/ImageSlideshow.tsx
+++ b/src/ImageSlideshow.tsx
@@ -20,13 +20,13 @@ const ImageSlideshow = () => {
             title: 'iBus',
             year: 2009,
             imageurl: 'https://alchetron.com/cdn/ibus-london-e3a5cd17-b7ec-4eeb-957d-17d1069ae3c-resize-750.jpg',
-            caption: 'Roll out of iBus, providing Nextstop audio and signs and live information on apps and the web'
+            caption: 'Roll out of iBus, providing Nextstop audio and signs and live information on apps and the web.'
         },
         {
             title: 'TfL Go',
             year: 2021,
             imageurl: 'https://tfl.gov.uk/cdn/static/cms/images/promos/tfl-go-jp_rdax_400x300.jpg',
-            caption: 'The first journey planning app released by TfL'
+            caption: 'The first journey planning app released by TfL.'
         }
         
     ];


### PR DESCRIPTION
Just adds a couple more slides to the History page.

<img width="1646" height="971" alt="Screenshot 2025-07-10 164153" src="https://github.com/user-attachments/assets/8dd17233-8d0f-43a8-a110-405d3a1f1702" />
<img width="1671" height="1003" alt="Screenshot 2025-07-10 164202" src="https://github.com/user-attachments/assets/78a07d30-02d7-419f-aea2-22aa6139a38a" />


